### PR TITLE
Fix code exchange error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ app.get('/install', (req, res) => {
 // Receive the authorization code from the OAuth 2.0 Server,
 // and process it based on the query parameters that are passed
 app.get('/oauth-callback', async (req, res) => {
-  console.log(req.sessionID);
   console.log('Step 3: Handling the request sent by the server');
 
   // Received a user authorization code, so now combine that with the other

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ app.get('/oauth-callback', async (req, res) => {
     console.log('Step 4: Exchanging authorization code for an access token and refresh token');
     const token = await exchangeForTokens(req.sessionID, authCodeProof);
     if (token.message) {
-      return res.redirect(`/error?msg=${error.message}`);
+      return res.redirect(`/error?msg=${token.message}`);
     }
 
     // Once the tokens have been retrieved, use them to make a query


### PR DESCRIPTION
Previously, if an error occured when exchanging an authorization code for a set of OAuth 2.0 tokens, the Node server would crash with an unhelpful message:
```
(node:93134) UnhandledPromiseRejectionWarning: ReferenceError: error is not defined
    at app.get (***/oauth-quickstart-nodejs/index.js:74:41)
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
(node:93134) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:93134) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
This was caused by an attempt to reference an object called `error` when there was no such object defined in the scope (the correct object was called `token`). This PR fixes that.

Also removes an unnecessary console.log call with sessionID

### Testing

I ran the node server locally and passed an invalid authorization code in the code/token exchange request. This returned an error, which was handled correctly by the Node server.