### PR TITLE
Scopes env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ _**Note:** You must be a super-admin for the portal that you want to install the
    ```
    CLIENT_ID='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
    CLIENT_SECRET='yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy'
-   SCOPES='contacts,hubdb'
+   SCOPE='contacts,forms'
    ```
-   You can also add a `SCOPES` environment variable to specify a custom set of scopes. The scopes can be separated by a comma, space, or URL-encoded space (`%20`)
+   You can also add a `SCOPE` environment variable to specify a custom set of scopes. The scopes can be separated by a comma, space, or URL-encoded space (`%20`)
 3. From the root of the repository, run:
    ```bash
    $ yarn install

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ _**Note:** You must be a super-admin for the portal that you want to install the
    ```
    CLIENT_ID='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
    CLIENT_SECRET='yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy'
+   SCOPES='contacts,hubdb'
    ```
+   You can also add a `SCOPES` environment variable to specify a custom set of scopes. The scopes can be separated by a comma, space, or URL-encoded space (`%20`)
 3. From the root of the repository, run:
    ```bash
    $ yarn install

--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ const app = express();
 
 const CLIENT_ID = process.env.CLIENT_ID;
 const CLIENT_SECRET = process.env.CLIENT_SECRET;
+// Supports a list of scopes as a string delimited by ',' or ' ' or '%20'
+const SCOPES = (process.env.SCOPES.split(/ |, ?|%20/) || ['contacts']).join(' ');
 
-const SCOPES = ['contacts'].join(' ');
 const REDIRECT_URI = `http://localhost:${PORT}/oauth-callback`;
 
 const refreshTokenStore = {};

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const app = express();
 const CLIENT_ID = process.env.CLIENT_ID;
 const CLIENT_SECRET = process.env.CLIENT_SECRET;
 // Supports a list of scopes as a string delimited by ',' or ' ' or '%20'
-const SCOPES = (process.env.SCOPES.split(/ |, ?|%20/) || ['contacts']).join(' ');
+const SCOPES = (process.env.SCOPE.split(/ |, ?|%20/) || ['contacts']).join(' ');
 
 const REDIRECT_URI = `http://localhost:${PORT}/oauth-callback`;
 


### PR DESCRIPTION
As was suggested in #1, this allows the scopes being requested by the quickstart app to be defined in an environment variable called `SCOPES`. Scopes can be separated by a comma, space, or url-encoded space (%20). Examples:

`SCOPES='contacts,hubdb'`
`SCOPES='contacts hubdb'`
`SCOPES='contacts%20hubdb'`

Also updates the docs to describe the scopes environment variable