### PR TITLE
Dockerize quickstart app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:8.15.1-alpine
+
+WORKDIR /usr/src/oauth-quickstart-nodejs
+
+# Install
+COPY ./index.js ./
+COPY ./package.json ./
+RUN npm install
+
+ENV CLIENT_ID=""
+ENV CLIENT_SECRET=""
+ENV SCOPES=""
+
+EXPOSE 3000
+
+ENTRYPOINT [ "node", "index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 
 ENV CLIENT_ID=""
 ENV CLIENT_SECRET=""
-ENV SCOPES=""
+ENV SCOPE=""
 
 EXPOSE 3000
 


### PR DESCRIPTION
Adds a Dockerfile to build the quickstart app into a docker container. This will let anyone who has Docker installed run the quickstart with only 2 lines of code:
```
$ docker build -t hs-oauth-quickstart:latest https://github.com/HubSpot/oauth-quickstart-nodejs.git
$ docker run -it --init -p 3000:3000 -e CLIENT_ID=$CLIENT_ID -e CLIENT_SECRET=$CLIENT_SECRET hs-oauth-quickstart:latest
```