### PR TITLE
Generate string for sessions config

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,11 @@ const refreshTokenStore = {};
 const accessTokenCache = new NodeCache({ deleteOnExpire: true });
 
 // Use a session to keep track of client ID
-app.use(session({ secret: CLIENT_SECRET, resave: false, saveUninitialized: true }));
+app.use(session({
+  secret: Math.random().toString(36).substring(2),
+  resave: false,
+  saveUninitialized: true
+}));
 
 //================================//
 //   Running the OAuth 2.0 Flow   //


### PR DESCRIPTION
It was confusing for someone unfamiliar with the sessions middleware to use the client secret for configuration (it looks like the session is tied to the client secret when it's not). This changes that configuration value to be a pseudo-random string, which should help alleviate that confusion when reading through it. Doesn't actually change the behavior of the quickstart - this is purely for clarity when reading the code