### PR TITLE
Update scopes requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,9 @@ if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET) {
 const CLIENT_ID = process.env.CLIENT_ID;
 const CLIENT_SECRET = process.env.CLIENT_SECRET;
 
-// Scopes for this app will default to `contacts`
+// Scopes for this app will default to `crm.objects.contacts.read`
 // To request others, set the SCOPE environment variable instead
-let SCOPES = ['contacts'];
+let SCOPES = ['crm.objects.contacts.read'];
 if (process.env.SCOPE) {
     SCOPES = (process.env.SCOPE.split(/ |, ?|%20/)).join(' ');
 }


### PR DESCRIPTION
Following the example app provided, requesting the `contacts` scope did not seem to work when redirecting back to the local app, as only the `crm.objects.contacts.read` is prompted to be added during onboarding. By updating this, the redirect flow works properly.