### PR TITLE
Update OAuth README to remove legacy developer account references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ _**Note:** This app does not store any data in a persistent way, so restarting t
 
 2. **Exchange an authorization code for access tokens**
 
-   Now that you're back in the app, it will retrieve an access token and refresh token from HubSpot's server, using an
-   authorization code that was supplied by HubSpot when you granted access to the app.
+   Now that you're back in the app, it will retrieve an access token and a refresh token from HubSpot's server, using an
+   The authorization code is provided by HubSpot when you grant the app access.
 
 3. **Retrieve a contact**
 
    When the app has received an access token, it will redirect you to `http://localhost:3000/`. It will then use the access token to
-   make a query to HubSpot's Contacts API, and display the retrieved contact's name on the page.
+   make a query to HubSpot's Contacts API and display the retrieved contact's name on the page.
    
 ## Prerequisites
 
@@ -29,9 +29,9 @@ Before running the quickstart app, make sure you have:
 1. The tools required to run using the method of your choice:
    - Option 1: Running locally using Node.js: [Node.js (>=6)](https://nodejs.org) and [yarn](https://yarnpkg.com/en/docs/install)
    - Option 2: Running in a Docker container: [Docker (>=1.13)](https://docs.docker.com/install/)
-2. A free HubSpot developer account ([sign up](https://app.hubspot.com/signup/developers))
-3. An app associated with your developer account ([create an app](https://developers.hubspot.com/docs/faq/how-do-i-create-an-app-in-hubspot))
-4. A HubSpot account to install the app in (you can use an existing one, or [create a test account](https://developers.hubspot.com/docs/faq/how-do-i-create-a-test-account))
+2. A HubSpot account ([sign up](https://developers.hubspot.com/docs/getting-started/account-types))
+3. An app associated with your developer account on the latest developer platform version ([create an app](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/create-an-app))
+4. A HubSpot account to install the app in (you can use an existing one, or [create a test account](https://developers.hubspot.com/docs/getting-started/account-types#developer-test-accounts))
 
 _**Note:** You must be a super-admin for the account that you want to install the app in._
 


### PR DESCRIPTION
I updated the README to replace legacy “developer account” language with current “HubSpot account” terminology and to update links so they no longer point users to legacy app creation flows.